### PR TITLE
Remove destructor

### DIFF
--- a/src/Fortran-interface/bml_allocate_m.F90
+++ b/src/Fortran-interface/bml_allocate_m.F90
@@ -30,8 +30,9 @@ contains
     character(len=*), intent(in) :: matrix_type, element_type
     integer, intent(in) :: element_precision
     integer(C_INT), intent(in) :: n, m
-    type(bml_matrix_t), intent(out) :: a
+    type(bml_matrix_t), intent(inout) :: a
 
+    call bml_deallocate(a)
     a%ptr = bml_zero_matrix_C(get_matrix_id(matrix_type), &
         & get_element_id(element_type, element_precision), n, m)
 
@@ -54,8 +55,9 @@ contains
     character(len=*), intent(in) :: matrix_type, element_type
     integer, intent(in) :: element_precision
     integer(C_INT), intent(in) :: n, m
-    type(bml_matrix_t), intent(out) :: a
+    type(bml_matrix_t), intent(inout) :: a
 
+    call bml_deallocate(a)
     a%ptr = bml_banded_matrix_C(get_matrix_id(matrix_type), &
         & get_element_id(element_type, element_precision), n, m)
 
@@ -78,8 +80,9 @@ contains
     character(len=*), intent(in) :: matrix_type, element_type
     integer, intent(in) :: element_precision
     integer(C_INT), intent(in) :: n, m
-    type(bml_matrix_t), intent(out) :: a
+    type(bml_matrix_t), intent(inout) :: a
 
+    call bml_deallocate(a)
     a%ptr = bml_random_matrix_C(get_matrix_id(matrix_type), &
         & get_element_id(element_type, element_precision), n, m)
 
@@ -102,8 +105,9 @@ contains
     character(len=*), intent(in) :: matrix_type, element_type
     integer, intent(in) :: element_precision
     integer(C_INT), intent(in) :: n, m
-    type(bml_matrix_t), intent(out) :: a
+    type(bml_matrix_t), intent(inout) :: a
 
+    call bml_deallocate(a)
     a%ptr = bml_identity_matrix_C(get_matrix_id(matrix_type), &
         & get_element_id(element_type, element_precision), n, m)
 

--- a/src/Fortran-interface/bml_copy_m.F90
+++ b/src/Fortran-interface/bml_copy_m.F90
@@ -20,7 +20,7 @@ contains
   subroutine bml_copy(a, b)
 
     type(bml_matrix_t), intent(in) :: a
-    type(bml_matrix_t), intent(out) :: b
+    type(bml_matrix_t), intent(inout) :: b
 
     call bml_deallocate(b)
     b%ptr = bml_copy_new_C(a%ptr)

--- a/src/Fortran-interface/bml_transpose_m.F90
+++ b/src/Fortran-interface/bml_transpose_m.F90
@@ -16,8 +16,9 @@ contains
   subroutine bml_transpose(a, a_t)
 
     type(bml_matrix_t), intent(in) :: a
-    type(bml_matrix_t), intent(out) :: a_t
+    type(bml_matrix_t), intent(inout) :: a_t
 
+    call bml_deallocate(a_t)
     a_t%ptr = bml_transpose_new_C(a%ptr)
 
   end subroutine bml_transpose

--- a/src/Fortran-interface/bml_types_m.F90
+++ b/src/Fortran-interface/bml_types_m.F90
@@ -8,24 +8,33 @@ module bml_types_m
   public :: BML_MATRIX_DENSE, BML_MATRIX_ELLPACK
   public :: BML_ELEMENT_REAL, BML_ELEMENT_COMPLEX
 
+  ! NOTE: The object oriented approach using destructors, which would make
+  ! explicit bml_deallocate() unnecessary and would prevent memory leaks, has
+  ! been disabled, as the GNU Fortran compiler up to version 5.2 is not able
+  ! create reliably working code. Once the reported bug
+  !     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68778 
+  ! is resolved, destructors can be enabled again, and the bml_deallocate()
+  ! calls can vanish from the library and from user code as well. (BA)
+
+  
   !> The bml vector type.
   type :: bml_vector_t
      !> The C pointer to the vector.
      type(C_PTR) :: ptr = C_NULL_PTR
-  contains
-     procedure :: bml_vector_t_assign
-     generic :: assignment(=) => bml_vector_t_assign
-     final :: destruct_bml_vector_t
+  !contains
+  !   procedure :: bml_vector_t_assign
+  !   generic :: assignment(=) => bml_vector_t_assign
+  !   final :: destruct_bml_vector_t
   end type bml_vector_t
 
   !> The bml matrix type.
   type :: bml_matrix_t
      !> The C pointer to the matrix.
      type(C_PTR) :: ptr = C_NULL_PTR
-  contains
-     procedure :: bml_matrix_t_assign
-     generic :: assignment(=) => bml_matrix_t_assign
-     final :: destruct_bml_matrix_t
+  !contains
+  !   procedure :: bml_matrix_t_assign
+  !   generic :: assignment(=) => bml_matrix_t_assign
+  !   final :: destruct_bml_matrix_t
   end type bml_matrix_t
 
   !> The bml-dense matrix type identifier.
@@ -59,43 +68,43 @@ contains
   end subroutine bml_deallocate
 
 
-  subroutine bml_vector_t_assign(this, other)
-    class(bml_vector_t), intent(inout) :: this
-    class(bml_vector_t), intent(in) :: other
-
-    print *, "Direct assignment between vectors not implemented"
-    error stop
-
-  end subroutine bml_vector_t_assign
-
-
-  subroutine destruct_bml_vector_t(this)
-    type(bml_vector_t), intent(inout) :: this
-
-    print *, "DESTRUCTOR for bml_vector not implemented yet."
-    print *, "You possibly leak memory here."
-    this%ptr = C_NULL_PTR
-    
-  end subroutine destruct_bml_vector_t
-
-
-  subroutine bml_matrix_t_assign(this, other)
-    class(bml_matrix_t), intent(out) :: this
-    class(bml_matrix_t), intent(in) :: other
-
-    if (c_associated(other%ptr)) then
-      this%ptr = bml_copy_new_C(other%ptr)
-    end if
-    
-  end subroutine bml_matrix_t_assign
-
-
-  subroutine destruct_bml_matrix_t(this)
-    type(bml_matrix_t), intent(inout) :: this
-
-      call bml_deallocate(this)
-
-  end subroutine destruct_bml_matrix_t
+  !subroutine bml_vector_t_assign(this, other)
+  !  class(bml_vector_t), intent(inout) :: this
+  !  class(bml_vector_t), intent(in) :: other
+  !
+  !  print *, "Direct assignment between vectors not implemented"
+  !  error stop
+  !
+  !end subroutine bml_vector_t_assign
+  !
+  !
+  !subroutine destruct_bml_vector_t(this)
+  !  type(bml_vector_t), intent(inout) :: this
+  !
+  !  print *, "DESTRUCTOR for bml_vector not implemented yet."
+  !  print *, "You possibly leak memory here."
+  !  this%ptr = C_NULL_PTR
+  !  
+  !end subroutine destruct_bml_vector_t
+  !
+  !
+  !subroutine bml_matrix_t_assign(this, other)
+  !  class(bml_matrix_t), intent(out) :: this
+  !  class(bml_matrix_t), intent(in) :: other
+  !
+  !  if (c_associated(other%ptr)) then
+  !    this%ptr = bml_copy_new_C(other%ptr)
+  !  end if
+  !  
+  !end subroutine bml_matrix_t_assign
+  !
+  !
+  !subroutine destruct_bml_matrix_t(this)
+  !  type(bml_matrix_t), intent(inout) :: this
+  !
+  !    call bml_deallocate(this)
+  !
+  !end subroutine destruct_bml_matrix_t
     
 
 end module bml_types_m


### PR DESCRIPTION
Let's disable the destructor in the type `bml_matrix_t` again ( :-1: ), requiring the users to use explicit deallocation routines in order to avoid memory leaks, but restoring compatibility with the buggy gfortran compiler. ( :+1: ). 