### PR TITLE
Updated README and Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
-language: c
+# We build on a matrix across difference compiler versions. If we specify C or
+# C++ for the language, then Travis-CI will export either the CC or CXX
+# variable to the environment but not both. Setting the language to something
+# other we avoid this behavior and drive the build matrix solely through the
+# environment.
+language: python
 
 addons:
   apt:
@@ -30,8 +35,6 @@ addons:
     - valgrind
 
 env:
-  - CC=gcc     CXX=g++     FC=gfortran     GCOV=gcov     BML_OPENMP=no  COMMAND=testing
-  - CC=gcc     CXX=g++     FC=gfortran     GCOV=gcov     BML_OPENMP=yes COMMAND=testing
   - CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 GCOV=gcov-4.7 BML_OPENMP=no  COMMAND=testing
   - CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 GCOV=gcov-4.7 BML_OPENMP=yes COMMAND=testing
   - CC=gcc-4.8 CXX=g++-4.8 FC=gfortran-4.8 GCOV=gcov-4.8 BML_OPENMP=no  COMMAND=testing
@@ -46,7 +49,7 @@ env:
   - BML_OPENMP=no  VERBOSE_MAKEFILE=yes COMMAND=indent
 
 before_script:
-  - pip install --user codecov
+  - pip install codecov
 
 script:
   - CMAKE_BUILD_TYPE=Debug BUILD_SHARED_LIBS=yes VERBOSE_MAKEFILE=yes ./build.sh ${COMMAND}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | [![Build Status](https://travis-ci.org/qmmd/bml.svg?branch=master)](https://travis-ci.org/qmmd/bml) | [![Build Status](https://travis-ci.org/qmmd/bml.svg?branch=develop)](https://travis-ci.org/qmmd/bml) |
 | [![codecov.io](https://codecov.io/github/qmmd/bml/coverage.svg?branch=master)](https://codecov.io/github/qmmd/bml?branch=master) | [![codecov.io](https://codecov.io/github/qmmd/bml/coverage.svg?branch=develop)](https://codecov.io/github/qmmd/bml?branch=develop) |
 
-# Build Instructions #
+# Build Instructions
 
 The bml library is built with CMake.  For your convenience, we provide
 a shell script which goes through the necessary motions and builds the
@@ -37,15 +37,16 @@ To build with MPI, OpenMP, and use Intel MKL do the following.
 
     $ CC=mpicc FC=mpif90 BLAS_VENDOR=Intel CMAKE_BUILD_TYPE=Release BML_OPENMP=yes BML_MPI=yes CMAKE_INSTALL_PREFIX=/some/path ./build.sh configure
 
-## Prerequisites ##
+## Prerequisites
 
 In order to build the library, the following tools need to be installed:
 
 - `gcc` with Fortran support
 - `>=cmake-2.8.8`
 - `>=python-2.7`
+- `>=OpenMP-3.1` (i.e. `>=gcc-4.7)
 
-## If the build fails ##
+## If the build fails
 
 In case the build fails for some reason, please email the developers
 at <qmmd-all@lanl.gov> or open an issue on github
@@ -54,14 +55,14 @@ at <qmmd-all@lanl.gov> or open an issue on github
     build/CMakeFiles/CMakeOutput.log
     build/CMakeFiles/CMakeError.log
 
-# Developer Suggested Workflow #
+# Developer Suggested Workflow
 
 We do our main development on the `develop` branch.  If you would like
 to contribute your work to the bml project, please fork the project on
 github, hack away at the forked `develop` branch and send us a pull
 request once you think we should have a look and integrate your work.
 
-## Coding Style ##
+## Coding Style
 
 Please indent your C code using
 
@@ -69,7 +70,7 @@ Please indent your C code using
 
 You can use the script `indent.sh` to indent all C code.
 
-# Citing #
+# Citing
 
 If you find this library useful, we encourage you to cite us. Our project has
 a citable DOI:
@@ -85,7 +86,7 @@ with the following `bibtex` snipped:
       year = 2016
     }
 
-# License #
+# License
 
 The bml library is licensed under the BSD 3-clause license.
 

--- a/src/C-interface/bml_allocate.c
+++ b/src/C-interface/bml_allocate.c
@@ -114,6 +114,7 @@ bml_deallocate_domain(
     bml_free_memory(D->localRowExtent);
     bml_free_memory(D->localDispl);
     bml_free_memory(D->localElements);
+    bml_free_memory(D);
 }
 
 /** Deallocate a matrix.
@@ -423,8 +424,8 @@ bml_default_domain(
     domain->localRowMin = bml_allocate_memory(nRanks * sizeof(int));
     domain->localRowMax = bml_allocate_memory(nRanks * sizeof(int));
     domain->localRowExtent = bml_allocate_memory(nRanks * sizeof(int));
-    domain->localElements = bml_allocate_memory(nRanks * sizeof(int));
     domain->localDispl = bml_allocate_memory(nRanks * sizeof(int));
+    domain->localElements = bml_allocate_memory(nRanks * sizeof(int));
 
     domain->totalProcs = nRanks;
     domain->totalRows = N;

--- a/src/C-interface/dense/bml_allocate_dense.c
+++ b/src/C-interface/dense/bml_allocate_dense.c
@@ -17,9 +17,6 @@ bml_deallocate_dense(
 {
     bml_deallocate_domain(A->domain);
     bml_deallocate_domain(A->domain2);
-
-    bml_free_memory(A->domain);
-    bml_free_memory(A->domain2);
     bml_free_memory(A->matrix);
     bml_free_memory(A);
 }

--- a/src/C-interface/dense/bml_allocate_dense_typed.c
+++ b/src/C-interface/dense/bml_allocate_dense_typed.c
@@ -88,9 +88,6 @@ bml_matrix_dense_t *TYPED_FUNC(
             A_dense[ROWMAJOR(i, j, N, N)] = rand() / (double) RAND_MAX;
         }
     }
-
-    A->domain = bml_default_domain(N, N, distrib_mode);
-    A->domain2 = bml_default_domain(N, N, distrib_mode);
     return A;
 }
 
@@ -122,8 +119,6 @@ bml_matrix_dense_t *TYPED_FUNC(
             A_dense[ROWMAJOR(i, j, N, N)] = rand() / (double) RAND_MAX;
         }
     }
-    A->domain = bml_default_domain(N, N, distrib_mode);
-    A->domain2 = bml_default_domain(N, N, distrib_mode);
     return A;
 }
 
@@ -152,7 +147,5 @@ bml_matrix_dense_t *TYPED_FUNC(
     {
         A_dense[ROWMAJOR(i, i, N, N)] = 1;
     }
-    A->domain = bml_default_domain(N, N, distrib_mode);
-    A->domain2 = bml_default_domain(N, N, distrib_mode);
     return A;
 }

--- a/src/C-interface/ellpack/bml_allocate_ellpack.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack.c
@@ -19,9 +19,6 @@ bml_deallocate_ellpack(
 {
     bml_deallocate_domain(A->domain);
     bml_deallocate_domain(A->domain2);
-
-    bml_free_memory(A->domain);
-    bml_free_memory(A->domain2);
     bml_free_memory(A->value);
     bml_free_memory(A->index);
     bml_free_memory(A->nnz);

--- a/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
@@ -146,8 +146,6 @@ bml_matrix_ellpack_t *TYPED_FUNC(
         }
         A_nnz[i] = jind;
     }
-    A->domain = bml_default_domain(N, M, distrib_mode);
-    A->domain2 = bml_default_domain(N, M, distrib_mode);
     return A;
 }
 
@@ -191,8 +189,6 @@ bml_matrix_ellpack_t *TYPED_FUNC(
         }
         A_nnz[i] = jind;
     }
-    A->domain = bml_default_domain(N, M, distrib_mode);
-    A->domain2 = bml_default_domain(N, M, distrib_mode);
     return A;
 }
 
@@ -231,7 +227,5 @@ bml_matrix_ellpack_t *TYPED_FUNC(
         A_index[ROWMAJOR(i, 0, N, M)] = i;
         A_nnz[i] = 1;
     }
-    A->domain = bml_default_domain(N, M, distrib_mode);
-    A->domain2 = bml_default_domain(N, M, distrib_mode);
     return A;
 }

--- a/src/C-interface/ellsort/bml_allocate_ellsort.c
+++ b/src/C-interface/ellsort/bml_allocate_ellsort.c
@@ -19,9 +19,6 @@ bml_deallocate_ellsort(
 {
     bml_deallocate_domain(A->domain);
     bml_deallocate_domain(A->domain2);
-
-    bml_free_memory(A->domain);
-    bml_free_memory(A->domain2);
     bml_free_memory(A->value);
     bml_free_memory(A->index);
     bml_free_memory(A->nnz);

--- a/src/C-interface/ellsort/bml_allocate_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_allocate_ellsort_typed.c
@@ -146,8 +146,6 @@ bml_matrix_ellsort_t *TYPED_FUNC(
         }
         A_nnz[i] = jind;
     }
-    A->domain = bml_default_domain(N, M, distrib_mode);
-    A->domain2 = bml_default_domain(N, M, distrib_mode);
     return A;
 }
 
@@ -191,8 +189,6 @@ bml_matrix_ellsort_t *TYPED_FUNC(
         }
         A_nnz[i] = jind;
     }
-    A->domain = bml_default_domain(N, M, distrib_mode);
-    A->domain2 = bml_default_domain(N, M, distrib_mode);
     return A;
 }
 
@@ -231,7 +227,5 @@ bml_matrix_ellsort_t *TYPED_FUNC(
         A_index[ROWMAJOR(i, 0, N, M)] = i;
         A_nnz[i] = 1;
     }
-    A->domain = bml_default_domain(N, M, distrib_mode);
-    A->domain2 = bml_default_domain(N, M, distrib_mode);
     return A;
 }


### PR DESCRIPTION
We require >=OpenMP-3.1 which was added to gcc-4.7. I made a note of
that in the README and removed the Travis compiler tests for <gcc-4.7.