### PR TITLE
Add link to binary packages from OBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 | [![Build Status](https://travis-ci.org/qmmd/bml.svg?branch=master)](https://travis-ci.org/qmmd/bml) | [![Build Status](https://travis-ci.org/qmmd/bml.svg?branch=develop)](https://travis-ci.org/qmmd/bml) |
 | [![codecov.io](https://codecov.io/github/qmmd/bml/coverage.svg?branch=master)](https://codecov.io/github/qmmd/bml?branch=master) | [![codecov.io](https://codecov.io/github/qmmd/bml/coverage.svg?branch=develop)](https://codecov.io/github/qmmd/bml?branch=develop) |
 
+# Binary Packages
+
+We offer binary packages of the bml library through [SUSE's OpenBuild
+Service](http://software.opensuse.org/download.html?project=home%3Anicolasbock%3Aqmmd&package=bml).
+
 # Build Instructions
 
 The bml library is built with CMake.  For your convenience, we provide


### PR DESCRIPTION
I started building binary packages for bml on OBS. This patch adds a
link to the package repository to the README file.