### PR TITLE
Bumping version to v1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(bml C CXX Fortran)
 # The library version is versioned off the major version. If the API
 # changes, the library version should be bumped.
 set(PROJECT_VERSION_MAJOR "1")
-set(PROJECT_VERSION_MINOR "0")
+set(PROJECT_VERSION_MINOR "1")
 set(PROJECT_VERSION_PATCH "0")
 
 set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")


### PR DESCRIPTION
I would like to release this as v1.1.0 so I can update the binary packages. Those will then go into the Travis-CI pipeline for progress.