### PR TITLE
Relax single precision test tolerance

### DIFF
--- a/tests/diagonalize_matrix_typed.c
+++ b/tests/diagonalize_matrix_typed.c
@@ -8,7 +8,7 @@
 
 
 #if defined(SINGLE_REAL) || defined(SINGLE_COMPLEX)
-#define REL_TOL 1e-5
+#define REL_TOL 1.2e-5
 #else
 #define REL_TOL 1e-11
 #endif


### PR DESCRIPTION
This accommodates a failing test:

diagonalize-ellpack-single_complex:
Error in matrix diagonalization; fnorm(CDC^t-A) = 1.127484e-05